### PR TITLE
Use local postcss-config and style-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "graphql-tag": "^2.5.0",
     "html-to-react": "^1.4.2",
     "lodash": "^4.17.4",
+    "postcss-nested": "^4.1.2",
     "prop-types": "^15.6.0",
     "react-apollo": "^2.1.3",
     "react-barcode": "^1.3.4",

--- a/src/components/PullSlip/PullSlip.js
+++ b/src/components/PullSlip/PullSlip.js
@@ -1,9 +1,17 @@
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Parser } from 'html-to-react';
 import template from './design/pullslip.handlebars';
-import './tmp.global-css';
+import style from '!!style-loader?injectType=lazyStyleTag!postcss-loader!./tmp.global-css';
 
 const PullSlip = (props) => {
+  useEffect(() => {
+    style.use();
+    return () => {
+      style.unuse();
+    };
+  }, []);
+
   const s = template(props.record);
   const htmlToReactParser = new Parser();
   return htmlToReactParser.parse(s);

--- a/src/components/PullSlip/postcss.config.js
+++ b/src/components/PullSlip/postcss.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  plugins: {
+    'postcss-import': {},
+    'autoprefixer': {},
+    'postcss-custom-properties': { preserve: false },
+    'postcss-calc': {},
+    'postcss-nested': {},
+    'postcss-custom-media': {},
+    'postcss-media-minmax': {},
+    'postcss-color-function': {}
+  }
+};

--- a/src/components/PullSlip/tmp.global-css
+++ b/src/components/PullSlip/tmp.global-css
@@ -3,12 +3,12 @@
     background: red;
 
     /* This does NOT work, inside the .page scope */
-    div.slip__section__header {
-	color: yellow;
+    .slip__section__header {
+        color: yellow;
     }
 }
 
 /* This does work, outside of the .page scope */
-p.slot--patron-name {
+.slot--patron-name {
     color: white;
 }


### PR DESCRIPTION
This depends on [#743 of stripes-core](https://github.com/folio-org/stripes-core/pull/743).

### PostCSS
Similar to other static analysis/transpilation tools (eslint, babel) PostCSS allows you to set local configurations where it will use the nearest ancestor it reaches. Here we've used that to include the necessary `postcss-nested` plugin with the rest of our current PostCSS plugin stack.

### Style loader
The import statement `!!style-loader?injectType=lazyStyleTag!postcss-loader!./tmp.global-css` engages the `lazyStyleTag` API of `style-loader`. This can be used in conjunction with a `.use()` `.unuse()` API  to insert a `<style>` tag at mount-time containing the imported styles, and, most importantly, remove them after the component dismounts.
