### PR TITLE
Remove unnecessary Eslint-disabling comments

### DIFF
--- a/src/routes/FlowRoute.js
+++ b/src/routes/FlowRoute.js
@@ -63,11 +63,11 @@ const FlowRoute = props => {
 FlowRoute.manifest = {
   selectedRecord: {
     type: 'okapi',
-    path: 'rs/patronrequests/:{id}', // eslint-disable-line no-template-curly-in-string,
+    path: 'rs/patronrequests/:{id}',
   },
   action: {
     type: 'okapi',
-    path: 'rs/patronrequests/:{id}/performAction', // eslint-disable-line no-template-curly-in-string,
+    path: 'rs/patronrequests/:{id}/performAction',
     fetch: false,
     clientGeneratePk: false,
   },


### PR DESCRIPTION
We never needed `eslint-disable-line no-template-curly-in-string` when using `:{xxx}`, only for `${xxx}` (which we no longer need since `%{xxx}` is a synonym). I'm not sure how these ESLint-disabling comments got added, but my best guess is careless copy-pasta from an over-paranoid module that uses these for _every_ manifest path due to having once needed it for a `${xxx}`.