### PR TITLE
Settings Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@folio/stripes-util": "^1.5.0",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",
+    "final-form-arrays": "^3.0.2",
     "graphql-tag": "^2.5.0",
     "handlebars": "^4.5.3",
     "html-to-react": "^1.4.2",

--- a/src/components/ViewPatronRequest/sections/AuditInfo.js
+++ b/src/components/ViewPatronRequest/sections/AuditInfo.js
@@ -37,7 +37,7 @@ class AuditInfo extends React.Component {
           <tbody>
             {
               audit.map((entry, i) => (
-                  <tr key={i}>
+                <tr key={i}>
                   <td>{audit.length - i}</td>
                   <td>{formattedDateTime(entry.dateCreated)}</td>
                   <td>{entry.fromStatus && <FormattedMessage id={`ui-rs.states.${entry.fromStatus.code}`} />}</td>

--- a/src/settings/settingsComponents/EditableSettingsList.js
+++ b/src/settings/settingsComponents/EditableSettingsList.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FieldArray } from 'react-final-form-arrays';
+import { Form } from 'react-final-form';
+import arrayMutators from 'final-form-arrays';
 
 import { Pane } from '@folio/stripes/components';
-import stripesFinalForm from '@folio/stripes/final-form';
 import { FormattedMessage } from 'react-intl';
 
 import EditableSettingsListFieldArray from './EditableSettingsListFieldArray';
@@ -11,7 +12,6 @@ import EditableSettingsListFieldArray from './EditableSettingsListFieldArray';
 class EditableSettingsList extends React.Component {
   static propTypes = {
     onSave: PropTypes.func,
-    form: PropTypes.object,
     data: PropTypes.shape({
       refdatavalues: PropTypes.arrayOf(PropTypes.object)
     }),
@@ -25,42 +25,46 @@ class EditableSettingsList extends React.Component {
 
   render() {
     const {
-      form: { mutators },
       data
     } = this.props;
     return (
-      <Pane
-        defaultWidth="fill"
-        id={`settings-${this.props.settingSection}`}
-        paneTitle={<FormattedMessage id={`ui-rs.settingsSection.${this.props.settingSection}`} />}
+      <Form
+        onSubmit={this.handleSave}
+        initialValues={this.props.initialValues}
+        enableReinitialize
+        keepDirtyOnReinitialize
+        mutators={{
+          setSettingValue: (args, state, tools) => {
+            tools.changeValue(state, args[0], () => args[1]);
+          },
+          ...arrayMutators
+        }}
+        subscription={{ value: true }}
+        navigationCheck
       >
-        <form>
-          <FieldArray
-            component={EditableSettingsListFieldArray}
-            name="settings"
-            onSave={this.handleSave}
-            mutators={mutators}
-            data={{
-              refdatavalues: data?.refdatavalues
-            }}
-            initialValues={this.props.initialValues}
-          />
-        </form>
-      </Pane>
+        {({ handleSubmit, mutators }) => (
+          <Pane
+            defaultWidth="fill"
+            id={`settings-${this.props.settingSection}`}
+            paneTitle={<FormattedMessage id={`ui-rs.settingsSection.${this.props.settingSection}`} />}
+          >
+            <form onSubmit={handleSubmit}>
+              <FieldArray
+                component={EditableSettingsListFieldArray}
+                name="settings"
+                onSave={this.handleSave}
+                mutators={mutators}
+                data={{
+                  refdatavalues: data?.refdatavalues
+                }}
+                initialValues={this.props.initialValues}
+              />
+            </form>
+          </Pane>
+        )}
+      </Form>
     );
   }
 }
 
-export default stripesFinalForm({
-  enableReinitialize: true,
-  keepDirtyOnReinitialize: false,
-  mutators: {
-    setSettingValue: (args, state, tools) => {
-      tools.changeValue(state, args[0], () => args[1]);
-    },
-  },
-  subscription: {
-    value: true
-  },
-  navigationCheck: true,
-})(EditableSettingsList);
+export default EditableSettingsList;


### PR DESCRIPTION
This PR refactors the oft-broken settings component in order to force it into lint with other ui-rs forms, and hopefully fix the recurring `useFieldArray must be used inside of a <Form> component` error.
Also a small tweak to code elsewhere to fix a linting error