### PR TITLE
PR-1018: Request cancellation response alert displays after response has been sent

### DIFF
--- a/src/components/ViewMessageBanners.js
+++ b/src/components/ViewMessageBanners.js
@@ -13,30 +13,40 @@ const ViewMessageBanners = ({ request }) => {
     condition => condition.relevantSupplier?.id === request.resolvedSupplier?.id && condition.accepted === true
   );
 
-  return (
-    <>
-      {request?.requesterRequestedCancellation ?
-        <MessageBanner
-          type="warning"
-        >
-          <FormattedMessage id="ui-rs.actions.requesterRequestedCancellation" />
-        </MessageBanner> : null
-      }
-      {relevantPendingConditions.length > 0 ?
+  const cancellationRequested = request?.state?.code === 'RES_CANCEL_REQUEST_RECEIVED';
+
+  const renderConditionsBanner = () => {
+    if (relevantPendingConditions.length > 0) {
+      return (
         <MessageBanner
           type="warning"
         >
           <SafeHTMLMessage id="ui-rs.actions.requestPendingLoanConditions" />
-        </MessageBanner> : null
-      }
-      { /* It's not particularly useful to show two banners when there is a pending AND accepted request */}
-      {relevantAcceptedConditions.length > 0 && relevantPendingConditions.length === 0 ?
+        </MessageBanner>
+      );
+    } else if (relevantAcceptedConditions.length > 0) {
+      /* It's not particularly useful to show two banners when there is a pending AND accepted request */
+      return (
         <MessageBanner
           type="success"
         >
           <SafeHTMLMessage id="ui-rs.actions.requestAcceptedLoanConditions" />
-        </MessageBanner> : null
+        </MessageBanner>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <>
+      {cancellationRequested &&
+        <MessageBanner
+          type="warning"
+        >
+          <FormattedMessage id="ui-rs.actions.requesterRequestedCancellation" />
+        </MessageBanner>
       }
+      {renderConditionsBanner()}
     </>
   );
 };


### PR DESCRIPTION
Tweaked rendering of viewMessageBanners to reflect that now we don't have a direct flag on the patron request for requesterRequestedCancellation -- using state code instead