### PR TITLE
feat: Name editing, code viewing

### DIFF
--- a/src/settings/HostLMSLocations/index.js
+++ b/src/settings/HostLMSLocations/index.js
@@ -138,12 +138,13 @@ const HostLMSLocations = () => {
           actionCalls={actionCalls}
           columnMapping={{
             name: <FormattedMessage id="ui-rs.settings.lmsloc.hostLMSLocation" />,
+            code: <FormattedMessage id="ui-rs.settings.lmsloc.code" />,
             supplyPreference: <FormattedMessage id="ui-rs.settings.lmsloc.supplyPreference" />,
             correspondingDirectoryEntry: <FormattedMessage id="ui-rs.settings.lmsloc.correspondingDirectoryEntry" />
           }}
           contentData={locations}
           editableFields={{
-            name: () => false
+            code: () => false
           }}
           fieldComponents={fieldComponents}
           formatter={{
@@ -157,7 +158,7 @@ const HostLMSLocations = () => {
             }
           }}
           hideCreateButton
-          visibleFields={['name', 'supplyPreference', 'correspondingDirectoryEntry']}
+          visibleFields={['name', 'code', 'supplyPreference', 'correspondingDirectoryEntry']}
         />
       </Pane>
       <FormModal

--- a/src/settings/HostLMSPatronProfiles/index.js
+++ b/src/settings/HostLMSPatronProfiles/index.js
@@ -98,15 +98,16 @@ const HostLMSPatronProfiles = () => {
           actionCalls={actionCalls}
           columnMapping={{
             name: <FormattedMessage id="ui-rs.settings.lmspprf.patronProfile" />,
+            code: <FormattedMessage id="ui-rs.settings.lmspprf.code" />,
             canCreateRequests: <FormattedMessage id="ui-rs.settings.lmspprf.canCreateRequests" />,
           }}
           contentData={locations}
           editableFields={{
-            name: () => false
+            code: () => false
           }}
           fieldComponents={fieldComponents}
           hideCreateButton
-          visibleFields={['name', 'canCreateRequests']}
+          visibleFields={['name', 'code', 'canCreateRequests']}
         />
       </Pane>
       <FormModal

--- a/src/settings/HostLMSShelvingLocations/index.js
+++ b/src/settings/HostLMSShelvingLocations/index.js
@@ -99,15 +99,16 @@ const HostLMSShelvingLocations = () => {
           actionCalls={actionCalls}
           columnMapping={{
             name: <FormattedMessage id="ui-rs.settings.lmsshlv.shelvingLocation" />,
+            code: <FormattedMessage id="ui-rs.settings.lmsshlv.code" />,
             supplyPreference: <FormattedMessage id="ui-rs.settings.lmsloc.supplyPreference" />,
           }}
           contentData={locations}
           editableFields={{
-            name: () => false
+            code: () => false
           }}
           fieldComponents={fieldComponents}
           hideCreateButton
-          visibleFields={['name', 'supplyPreference']}
+          visibleFields={['name', 'code', 'supplyPreference']}
         />
       </Pane>
       <FormModal


### PR DESCRIPTION
Added the ability to edit `name` fields inline for Host LMS locations, Host LMS patron profiles and Host LMS shelving locations, whilst also allowing view (but not edit) of `code` fields for all three

PR-1883