### PR TITLE
Fix X button on create/edit and tidy client paths PR-1680

### DIFF
--- a/src/components/PatronRequests/PatronRequests.js
+++ b/src/components/PatronRequests/PatronRequests.js
@@ -268,7 +268,7 @@ const PatronRequests = ({ requestsQuery, queryGetter, querySetter, filterOptions
                     loading={requestsQuery?.isFetching}
                     onHeaderClick={onSort}
                     onNeedMoreData={fetchMore}
-                    onRowClick={(_e, rowData) => history.push(`${match.url}/view/${rowData.id}${location.search}`)}
+                    onRowClick={(_e, rowData) => history.push(`${match.url}/${rowData.id}${location.search}`)}
                     sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
                     sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
                     totalCount={totalCount}

--- a/src/index.js
+++ b/src/index.js
@@ -35,28 +35,47 @@ const ResourceSharing = (props) => {
           from={path}
           to={`${path}/requests`}
         />
+
+        {/* Backwards compatibility for previous client-side URLs */}
+        <Redirect
+          exact
+          from={`${path}/requests/view/:id`}
+          to={`${path}/requests/:id${search}`}
+        />
+        <Redirect
+          exact
+          from={`${path}/requests/view/:id/flow`}
+          to={`${path}/requests/:id/flow${search}`}
+        />
+        <Redirect
+          exact
+          from={`${path}/requests/view/:id/details`}
+          to={`${path}/requests/:id/details${search}`}
+        />
+
+        <Redirect
+          exact
+          from={`${path}/requests/:id`}
+          to={`${path}/requests/:id/flow${search}`}
+        />
+
         {appName === 'request' &&
           <Route path={`${path}/requests/create`} component={CreateEditRoute} />
         }
         {appName === 'request' &&
-          <Route path={`${path}/requests/edit/:id`} component={CreateEditRoute} />
+          <Route path={`${path}/requests/:id/edit`} component={CreateEditRoute} />
         }
-        <Redirect
-          exact
-          from={`${path}/requests/view/:id`}
-          to={`${path}/requests/view/:id/flow${search}`}
-        />
-        <Route path={`${path}/requests/view/:id/pullslip`} component={PullSlipRoute} />
+        <Route path={`${path}/requests/:id/pullslip`} component={PullSlipRoute} />
         <Route path={`${path}/requests/batch/:batchId/pullslip`} component={PullSlipRoute} />
         {appName === 'request' &&
-          <Route path={`${path}/requests/view/:id/rerequest`} component={CreateEditRoute} />
+          <Route path={`${path}/requests/:id/rerequest`} component={CreateEditRoute} />
         }
         {appName === 'request' &&
-          <Route path={`${path}/requests/view/:id/revalidate`} component={CreateEditRoute} />
+          <Route path={`${path}/requests/:id/revalidate`} component={CreateEditRoute} />
         }
 
         {/* Contains nested routes: ./details and ./flow */}
-        <Route path={`${path}/requests/view/:id`} component={ViewRoute} />
+        <Route path={`${path}/requests/:id`} component={ViewRoute} />
 
         <Route
           path={`${path}/requests/:action?`}

--- a/src/routes/CreateEditRoute.js
+++ b/src/routes/CreateEditRoute.js
@@ -7,7 +7,7 @@ import { Prompt, useLocation } from 'react-router-dom';
 import { Button, Pane, Paneset, PaneMenu, KeyValue } from '@folio/stripes/components';
 import { CalloutContext, useOkapiKy } from '@folio/stripes/core';
 import { useAppSettings, useRefdata } from '@k-int/stripes-kint-components';
-import { selectifyRefdata, useOkapiQuery, usePerformAction } from '@projectreshare/stripes-reshare';
+import { selectifyRefdata, useCloseDirect, useOkapiQuery, usePerformAction } from '@projectreshare/stripes-reshare';
 import PatronRequestForm from '../components/PatronRequestForm';
 import { REFDATA_ENDPOINT, SETTINGS_ENDPOINT } from '../constants/endpoints';
 import { SERVICE_TYPE_COPY, SERVICE_TYPE_LOAN } from '../constants/serviceType';
@@ -45,6 +45,7 @@ const CreateEditRoute = props => {
   const intl = useIntl();
   const queryClient = useQueryClient();
   const okapiKy = useOkapiKy();
+  const close = useCloseDirect();
 
   const locQuery = useOkapiQuery('directory/entry', { searchParams: '?filters=(type.value%3D%3Dinstitution)%7C%7C(tags.value%3Di%3Dpickup)&filters=status.value%3D%3Dmanaged&perPage=100' });
   const reqQuery = useOkapiQuery(`rs/patronrequests/${id}`, { enabled: !!id });
@@ -67,7 +68,7 @@ const CreateEditRoute = props => {
     await new Promise(resolve => setTimeout(resolve, 3000));
     await queryClient.invalidateQueries(`rs/patronrequests/${id}`);
     await queryClient.invalidateQueries('rs/patronrequests');
-    history.goBack();
+    close();
   };
 
   const updater = useMutation({
@@ -193,7 +194,7 @@ const CreateEditRoute = props => {
           <Pane
             defaultWidth="100%"
             centerContent
-            onClose={history.goBack}
+            onClose={close}
             dismissible
             lastMenu={
               <PaneMenu>

--- a/src/routes/ViewRoute.js
+++ b/src/routes/ViewRoute.js
@@ -5,7 +5,7 @@ import { Route, Switch } from 'react-router-dom';
 
 import { useStripes } from '@folio/stripes/core';
 import { Button, ButtonGroup, Icon, Layout, Pane, PaneMenu, Paneset } from '@folio/stripes/components';
-import { upNLevels, useCloseDirect, usePerformAction, useOkapiQuery } from '@projectreshare/stripes-reshare';
+import { DirectLink, upNLevels, useCloseDirect, usePerformAction, useOkapiQuery } from '@projectreshare/stripes-reshare';
 
 import renderNamedWithProps from '../util/renderNamedWithProps';
 import { MessageModalProvider } from '../components/MessageModalState';
@@ -39,7 +39,7 @@ const ViewRoute = ({ location, location: { pathname }, match }) => {
   const appName = useContext(AppNameContext);
   const performAction = usePerformAction(id);
   const { handleMarkAllRead } = useChatActions(id);
-  const close = useCloseDirect(upNLevels(location, 3));
+  const close = useCloseDirect();
 
   // Fetch the request
   const { data: request = {}, isSuccess: hasRequestLoaded } = useOkapiQuery(`rs/patronrequests/${id}`, { staleTime: 2 * 60 * 1000, notifyOnChangeProps: 'tracked' });
@@ -120,11 +120,11 @@ const ViewRoute = ({ location, location: { pathname }, match }) => {
             <>
               {
                 appName === 'request' && stripes.hasPerm(`ui-${appName}.edit`) && (
-                  <Button buttonStyle="dropdownItem" to="edit" id="clickable-edit-patronrequest">
+                  <DirectLink component={Button} buttonStyle="dropdownItem" to="edit" id="clickable-edit-patronrequest">
                     <Icon icon="edit">
                       <FormattedMessage id="ui-rs.edit" />
                     </Icon>
-                  </Button>
+                  </DirectLink>
                 )
               }
               {request?.validActions?.includes('manualClose') &&

--- a/src/routes/ViewRoute.js
+++ b/src/routes/ViewRoute.js
@@ -120,7 +120,7 @@ const ViewRoute = ({ location, location: { pathname }, match }) => {
             <>
               {
                 appName === 'request' && stripes.hasPerm(`ui-${appName}.edit`) && (
-                  <Button buttonStyle="dropdownItem" to={`../../edit/${match.params.id}`} id="clickable-edit-patronrequest">
+                  <Button buttonStyle="dropdownItem" to="edit" id="clickable-edit-patronrequest">
                     <Icon icon="edit">
                       <FormattedMessage id="ui-rs.edit" />
                     </Icon>


### PR DESCRIPTION
Fixing the X button on the create/edit form necessitated either cleaning up the routes a bit (so it'd always just need to go up one level regardless of the context where the form was used) or adding in special cases for some of the 4+ places we use that form. I opted to change the routes as I think this organisation is a bit more sensible anyhow and I'd already been tempted to do this a time or two along the way.